### PR TITLE
PR for mod compatibilty with Public Gui Anouncement

### DIFF
--- a/src/main/resources/load_screens/pga_mod_compat.json
+++ b/src/main/resources/load_screens/pga_mod_compat.json
@@ -1,0 +1,9 @@
+{
+	"screens" : [
+		 {
+			"COMMENT" : "DEAD MAN SATCHEL SUPPORT", 
+			"class" : "com.builtbroken.deadmanssatchel.item.ContainerSatchel", 
+			"texture" : "deadmanssatchel:textures/gui/guibackground.png", 
+			"size" : [176, 151]
+		}]
+}


### PR DESCRIPTION
the PGA :
https://www.curseforge.com/minecraft/mc-mods/public-gui-announcement

The Wiki on how these JSON files work :
https://github.com/ArtixAllMighty/PublicGuiAnnouncement/wiki/Add-Mod-Compatibility

In this PR is contained one json file to add compatibility with the mod Public Gui Announcement.
I wanted to ship the compat at first with my mod, but it would be better if the author maintains it himself. (in case of path and name changes as well addition or removal from screens).

I hereby give you all files needed to add compatibility to my mod. There is nothing else left to do apart from merging the PR.

If you have any other question, I'd be happy to answer !